### PR TITLE
Implement CLI flags

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -1,0 +1,19 @@
+use clap::Parser;
+use std::path::PathBuf;
+
+/// Command line arguments for the chat CLI.
+#[derive(Debug, Parser)]
+#[command(author, version, about, long_about = None)]
+pub struct Cli {
+    /// Start a new conversation log at <FILE> and clear history
+    #[arg(long, value_name = "FILE")]
+    pub new: Option<PathBuf>,
+
+    /// Load an existing conversation log from <FILE>
+    #[arg(long, value_name = "FILE")]
+    pub load: Option<PathBuf>,
+
+    /// Override the default model name (default: mistral)
+    #[arg(long, default_value = "mistral", value_name = "MODEL")]
+    pub model: String,
+}

--- a/tasks/tasks-prd-local-chat-cli.md
+++ b/tasks/tasks-prd-local-chat-cli.md
@@ -21,7 +21,7 @@
   - [x] 1.1 Create `Cargo.toml` with necessary dependencies
   - [x] 1.2 Set up `src/main.rs` with async runtime entry point
 - [ ] 2.0 Implement CLI argument parsing
-  - [ ] 2.1 Define flags `--new`, `--load`, and `--model` in `src/cli.rs`
+  - [x] 2.1 Define flags `--new`, `--load`, and `--model` in `src/cli.rs`
   - [ ] 2.2 Hook CLI parsing into `main.rs`
 - [ ] 3.0 Build chat backend abstraction
   - [ ] 3.1 Define `ChatBackend` trait in `chat_backend.rs`


### PR DESCRIPTION
## Summary
- define CLI options in a new `src/cli.rs`
- mark task 2.1 completed in task list

## Testing
- `cargo check`
- `rustup component add rustfmt` *(fails: unsuccessful tunnel)*

------
https://chatgpt.com/codex/tasks/task_e_68490877684c83329b404725951c13ab