### PR TITLE
Implement ChatBackend trait

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -197,6 +197,7 @@ name = "chat-cli"
 version = "0.1.0"
 dependencies = [
  "async-openai",
+ "async-trait",
  "clap",
  "serde",
  "serde_json",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,3 +10,4 @@ async-openai = "0.18"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 tracing = "0.1"
+async-trait = "0.1"

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Chat CLI is a Rust command-line tool for interacting with a local large language
 
 ## Status
 
-The project is in early development. Currently the CLI accepts a few arguments and prints them back:
+The project is in early development. The CLI accepts a few arguments and now defines a simple backend abstraction via a `ChatBackend` trait (see `src/chat_backend.rs`):
 
 - `--new <FILE>` start a new conversation log.
 - `--load <FILE>` load an existing log.

--- a/src/chat_backend.rs
+++ b/src/chat_backend.rs
@@ -1,0 +1,15 @@
+use async_trait::async_trait;
+
+/// Represents a single chat message with a role and content.
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
+pub struct Message {
+    pub role: String,
+    pub content: String,
+}
+
+/// Trait for chat backends that can send and receive messages.
+#[async_trait]
+pub trait ChatBackend {
+    /// Send the conversation history and receive the assistant's reply as a string.
+    async fn chat(&self, messages: &[Message]) -> Result<String, Box<dyn std::error::Error + Send + Sync>>;
+}

--- a/tasks/tasks-prd-local-chat-cli.md
+++ b/tasks/tasks-prd-local-chat-cli.md
@@ -26,7 +26,7 @@
   - [x] 2.1 Define flags `--new`, `--load`, and `--model` in `src/cli.rs`
   - [x] 2.2 Hook CLI parsing into `main.rs`
 - [ ] 3.0 Build chat backend abstraction
-  - [ ] 3.1 Define `ChatBackend` trait in `chat_backend.rs`
+  - [x] 3.1 Define `ChatBackend` trait in `chat_backend.rs`
   - [ ] 3.2 Implement `OllamaBackend` using `async-openai`
 - [ ] 4.0 Create REPL loop and message handling
   - [ ] 4.1 Prompt user until `/exit` or EOF


### PR DESCRIPTION
## Summary
- add `ChatBackend` trait and `Message` struct
- document backend abstraction in README
- mark task 3.1 complete
- add `async-trait` dependency

## Testing
- `cargo test -- --nocapture`

------
https://chatgpt.com/codex/tasks/task_e_68490fa83bbc8332b7c82269fd21d722