### PR TITLE
Implement Ollama backend

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,10 @@ Chat CLI is a Rust command-line tool for interacting with a local large language
 
 ## Status
 
-The project is in early development. The CLI accepts a few arguments and now defines a simple backend abstraction via a `ChatBackend` trait (see `src/chat_backend.rs`):
+The project is in early development. The CLI accepts a few arguments and defines
+a simple backend abstraction via a `ChatBackend` trait (see
+`src/chat_backend.rs`). A first implementation using `async-openai` is provided
+in `src/ollama_backend.rs`:
 
 - `--new <FILE>` start a new conversation log.
 - `--load <FILE>` load an existing log.

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,4 +1,6 @@
 mod cli;
+mod chat_backend;
+mod ollama_backend;
 
 use clap::Parser;
 

--- a/src/ollama_backend.rs
+++ b/src/ollama_backend.rs
@@ -1,0 +1,66 @@
+use crate::chat_backend::{ChatBackend, Message};
+use async_openai::{Client, config::OpenAIConfig, types::{
+    ChatCompletionRequestAssistantMessageArgs,
+    ChatCompletionRequestMessage,
+    ChatCompletionRequestSystemMessageArgs,
+    ChatCompletionRequestUserMessageArgs,
+    CreateChatCompletionRequestArgs,
+}};
+use async_trait::async_trait;
+
+/// Chat backend that talks to a locally running Ollama server via OpenAI-compatible API.
+pub struct OllamaBackend {
+    client: Client<OpenAIConfig>,
+    model: String,
+}
+
+impl OllamaBackend {
+    /// Create a new backend targeting the given model.
+    pub fn new(model: impl Into<String>) -> Self {
+        let config = OpenAIConfig::new()
+            .with_api_base("http://localhost:11434/v1")
+            .with_api_key("none");
+        let client = Client::with_config(config);
+        Self { client, model: model.into() }
+    }
+}
+
+#[async_trait]
+impl ChatBackend for OllamaBackend {
+    async fn chat(&self, messages: &[Message]) -> Result<String, Box<dyn std::error::Error + Send + Sync>> {
+        let mut req_messages = Vec::new();
+        for m in messages {
+            let msg = match m.role.as_str() {
+                "system" => ChatCompletionRequestMessage::System(
+                    ChatCompletionRequestSystemMessageArgs::default()
+                        .content(m.content.clone())
+                        .build()?
+                ),
+                "assistant" => ChatCompletionRequestMessage::Assistant(
+                    ChatCompletionRequestAssistantMessageArgs::default()
+                        .content(m.content.clone())
+                        .build()?
+                ),
+                _ => ChatCompletionRequestMessage::User(
+                    ChatCompletionRequestUserMessageArgs::default()
+                        .content(m.content.clone())
+                        .build()?
+                ),
+            };
+            req_messages.push(msg);
+        }
+
+        let request = CreateChatCompletionRequestArgs::default()
+            .model(self.model.clone())
+            .messages(req_messages)
+            .build()?;
+
+        let response = self.client.chat().create(request).await?;
+        let reply = response
+            .choices
+            .first()
+            .and_then(|c| c.message.content.clone())
+            .unwrap_or_default();
+        Ok(reply)
+    }
+}

--- a/tasks/tasks-prd-local-chat-cli.md
+++ b/tasks/tasks-prd-local-chat-cli.md
@@ -25,9 +25,9 @@
 - [x] 2.0 Implement CLI argument parsing
   - [x] 2.1 Define flags `--new`, `--load`, and `--model` in `src/cli.rs`
   - [x] 2.2 Hook CLI parsing into `main.rs`
-- [ ] 3.0 Build chat backend abstraction
+- [x] 3.0 Build chat backend abstraction
   - [x] 3.1 Define `ChatBackend` trait in `chat_backend.rs`
-  - [ ] 3.2 Implement `OllamaBackend` using `async-openai`
+  - [x] 3.2 Implement `OllamaBackend` using `async-openai`
 - [ ] 4.0 Create REPL loop and message handling
   - [ ] 4.1 Prompt user until `/exit` or EOF
   - [ ] 4.2 Maintain `Vec<Message>` with `role` and `content`


### PR DESCRIPTION
## Summary
- implement `OllamaBackend` using `async-openai`
- expose backend modules from `main.rs`
- document backend implementation in README
- check off task 3.2 in task list

## Testing
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_e_6849241ddcf0833287b316be738c6193