### PR TITLE
Implement basic REPL loop

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,9 @@ Example:
 cargo run -- --new mylog.jsonl --model mistral
 ```
 
+After launching, the program prompts for your input in a simple REPL loop.
+Type `/exit` or press `Ctrl-D` to quit.
+
 Use `cargo run -- --help` to see all available options.
 
 ## Development

--- a/src/main.rs
+++ b/src/main.rs
@@ -3,6 +3,7 @@ mod chat_backend;
 mod ollama_backend;
 
 use clap::Parser;
+use std::io::{self, Write};
 
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
@@ -17,6 +18,23 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     }
 
     println!("Using model: {}", cli.model);
+
+    let stdin = io::stdin();
+    let mut input = String::new();
+
+    loop {
+        print!("> ");
+        io::stdout().flush()?;
+        input.clear();
+        if stdin.read_line(&mut input)? == 0 {
+            break;
+        }
+        let line = input.trim_end();
+        if line == "/exit" {
+            break;
+        }
+        println!("You said: {}", line);
+    }
 
     Ok(())
 }

--- a/tasks/tasks-prd-local-chat-cli.md
+++ b/tasks/tasks-prd-local-chat-cli.md
@@ -29,7 +29,7 @@
   - [x] 3.1 Define `ChatBackend` trait in `chat_backend.rs`
   - [x] 3.2 Implement `OllamaBackend` using `async-openai`
 - [ ] 4.0 Create REPL loop and message handling
-  - [ ] 4.1 Prompt user until `/exit` or EOF
+  - [x] 4.1 Prompt user until `/exit` or EOF
   - [ ] 4.2 Maintain `Vec<Message>` with `role` and `content`
   - [ ] 4.3 Stream responses as tokens arrive
 - [ ] 5.0 Support conversation persistence


### PR DESCRIPTION
## Summary
- implement a simple stdin REPL in `main.rs`
- mention `/exit` usage in README
- mark the REPL prompt task complete in task list

## Testing
- `cargo test --quiet`
- `cargo fmt` *(fails: 'cargo-fmt' is not installed)*

------
https://chatgpt.com/codex/tasks/task_e_6849257470e48332a00c330ed8141456