### PR TITLE
Implement streaming responses

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -199,6 +199,7 @@ dependencies = [
  "async-openai",
  "async-trait",
  "clap",
+ "futures-util",
  "serde",
  "serde_json",
  "tokio",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,3 +11,4 @@ serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 tracing = "0.1"
 async-trait = "0.1"
+futures-util = "0.3"

--- a/README.md
+++ b/README.md
@@ -12,8 +12,8 @@ in `src/ollama_backend.rs`:
 - `--new <FILE>` start a new conversation log.
 - `--load <FILE>` load an existing log.
 - `--model <NAME>` choose the model to use (default `mistral`).
-The CLI now sends each prompt to a locally running Ollama server and prints the assistant's reply.
-Future tasks will add streaming output and conversation persistence.
+The CLI now sends each prompt to a locally running Ollama server and streams the assistant's reply token by token.
+Future tasks will add conversation persistence.
 
 ## Building
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -41,7 +41,6 @@ async fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
         }
         messages.push(Message { role: "user".into(), content: line.to_string() });
         let reply = backend.chat(&messages).await?;
-        println!("{}", reply);
         messages.push(Message { role: "assistant".into(), content: reply });
     }
 

--- a/tasks/tasks-prd-local-chat-cli.md
+++ b/tasks/tasks-prd-local-chat-cli.md
@@ -28,10 +28,10 @@
 - [x] 3.0 Build chat backend abstraction
   - [x] 3.1 Define `ChatBackend` trait in `chat_backend.rs`
   - [x] 3.2 Implement `OllamaBackend` using `async-openai`
-- [ ] 4.0 Create REPL loop and message handling
+- [x] 4.0 Create REPL loop and message handling
   - [x] 4.1 Prompt user until `/exit` or EOF
   - [x] 4.2 Maintain `Vec<Message>` with `role` and `content`
-  - [ ] 4.3 Stream responses as tokens arrive
+  - [x] 4.3 Stream responses as tokens arrive
 - [ ] 5.0 Support conversation persistence
   - [ ] 5.1 Autoload default transcript on startup
   - [ ] 5.2 Autosave conversation after each turn


### PR DESCRIPTION
## Summary
- enable streaming from Ollama backend
- print tokens as they arrive and accumulate reply
- remove duplicate print in main
- document streaming in README
- mark streaming task complete

## Testing
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_684928e9e77c833290677141e615f35b